### PR TITLE
feat: major UX improvements for better accessibility

### DIFF
--- a/src/ui/header.rs
+++ b/src/ui/header.rs
@@ -137,22 +137,43 @@ pub fn render(f: &mut Frame, app: &App, area: Rect) {
     };
     f.render_widget(Paragraph::new(actions_line), rows[2]);
 
-    // Row 4: Help hint
-    let help_line = Line::from(vec![
-        Span::styled(
-            " ?:help  ::cmd  /:filter  p:projects  z:zones  q:quit",
-            Style::default().fg(Color::DarkGray),
-        ),
-        if app.readonly {
-            Span::styled(
-                "  [READ-ONLY]",
-                Style::default()
-                    .fg(Color::Yellow)
-                    .add_modifier(Modifier::BOLD),
-            )
-        } else {
-            Span::raw("")
-        },
-    ]);
+    // Row 4: Help hint - more accessible with clear labels
+    let mut help_spans = vec![
+        Span::styled(" ?", Style::default().fg(Color::Yellow)),
+        Span::styled(":help ", Style::default().fg(Color::DarkGray)),
+        Span::styled("↑↓", Style::default().fg(Color::Yellow)),
+        Span::styled(":nav ", Style::default().fg(Color::DarkGray)),
+        Span::styled("/", Style::default().fg(Color::Yellow)),
+        Span::styled(":filter ", Style::default().fg(Color::DarkGray)),
+        Span::styled("p", Style::default().fg(Color::Yellow)),
+        Span::styled(":proj ", Style::default().fg(Color::DarkGray)),
+        Span::styled("z", Style::default().fg(Color::Yellow)),
+        Span::styled(":zone ", Style::default().fg(Color::DarkGray)),
+        Span::styled("F1-F6", Style::default().fg(Color::Yellow)),
+        Span::styled(":sort ", Style::default().fg(Color::DarkGray)),
+    ];
+
+    // Add sort indicator if active
+    if let Some(col) = app.sort_column {
+        help_spans.push(Span::styled(
+            format!(
+                "[sorted:col{}{}]",
+                col + 1,
+                if app.sort_ascending { "↑" } else { "↓" }
+            ),
+            Style::default().fg(Color::Cyan),
+        ));
+    }
+
+    if app.readonly {
+        help_spans.push(Span::styled(
+            " [READ-ONLY]",
+            Style::default()
+                .fg(Color::Yellow)
+                .add_modifier(Modifier::BOLD),
+        ));
+    }
+
+    let help_line = Line::from(help_spans);
     f.render_widget(Paragraph::new(help_line), rows[3]);
 }

--- a/src/ui/help.rs
+++ b/src/ui/help.rs
@@ -13,7 +13,7 @@ use ratatui::{
 
 pub fn render(f: &mut Frame, _app: &App) {
     let area = f.area();
-    let popup_area = centered_rect(70, 80, area);
+    let popup_area = centered_rect(75, 85, area);
 
     f.render_widget(Clear, popup_area);
 
@@ -25,105 +25,133 @@ pub fn render(f: &mut Frame, _app: &App) {
                 .add_modifier(Modifier::BOLD),
         )),
         Line::from(""),
+        // Navigation section
         Line::from(vec![Span::styled(
             "Navigation",
             Style::default().add_modifier(Modifier::BOLD),
         )]),
         Line::from(vec![
-            Span::styled("  j/k, ↑/↓    ", Style::default().fg(Color::Yellow)),
+            Span::styled("  ↑/↓ or j/k      ", Style::default().fg(Color::Yellow)),
             Span::raw("Move up/down"),
         ]),
         Line::from(vec![
-            Span::styled("  gg          ", Style::default().fg(Color::Yellow)),
+            Span::styled("  Home or gg      ", Style::default().fg(Color::Yellow)),
             Span::raw("Go to top"),
         ]),
         Line::from(vec![
-            Span::styled("  G           ", Style::default().fg(Color::Yellow)),
+            Span::styled("  End or G        ", Style::default().fg(Color::Yellow)),
             Span::raw("Go to bottom"),
         ]),
         Line::from(vec![
-            Span::styled("  Ctrl+d/u    ", Style::default().fg(Color::Yellow)),
-            Span::raw("Page down/up"),
+            Span::styled("  PgUp/PgDn       ", Style::default().fg(Color::Yellow)),
+            Span::raw("Page up/down (or Ctrl+u/d)"),
         ]),
         Line::from(vec![
-            Span::styled("  [/]         ", Style::default().fg(Color::Yellow)),
-            Span::raw("Previous/next page"),
+            Span::styled("  1-9             ", Style::default().fg(Color::Yellow)),
+            Span::raw("Jump to item 1-9"),
+        ]),
+        Line::from(vec![
+            Span::styled("  [/]             ", Style::default().fg(Color::Yellow)),
+            Span::raw("Previous/next API page"),
         ]),
         Line::from(""),
+        // Sorting section
+        Line::from(vec![Span::styled(
+            "Sorting",
+            Style::default().add_modifier(Modifier::BOLD),
+        )]),
+        Line::from(vec![
+            Span::styled("  F1-F6           ", Style::default().fg(Color::Yellow)),
+            Span::raw("Sort by column 1-6 (toggle direction)"),
+        ]),
+        Line::from(vec![
+            Span::styled("  F12             ", Style::default().fg(Color::Yellow)),
+            Span::raw("Clear sort"),
+        ]),
+        Line::from(""),
+        // Views section
         Line::from(vec![Span::styled(
             "Views",
             Style::default().add_modifier(Modifier::BOLD),
         )]),
         Line::from(vec![
-            Span::styled("  Enter/d     ", Style::default().fg(Color::Yellow)),
-            Span::raw("View resource details"),
+            Span::styled("  Enter or d      ", Style::default().fg(Color::Yellow)),
+            Span::raw("View resource details (JSON)"),
         ]),
         Line::from(vec![
-            Span::styled("  b/Backspace ", Style::default().fg(Color::Yellow)),
+            Span::styled("  ← or Backspace  ", Style::default().fg(Color::Yellow)),
             Span::raw("Go back"),
         ]),
         Line::from(vec![
-            Span::styled("  R           ", Style::default().fg(Color::Yellow)),
+            Span::styled("  R               ", Style::default().fg(Color::Yellow)),
             Span::raw("Refresh current view"),
         ]),
         Line::from(""),
+        // Filtering section
         Line::from(vec![Span::styled(
             "Filtering",
             Style::default().add_modifier(Modifier::BOLD),
         )]),
         Line::from(vec![
-            Span::styled("  /           ", Style::default().fg(Color::Yellow)),
-            Span::raw("Start filtering"),
+            Span::styled("  /               ", Style::default().fg(Color::Yellow)),
+            Span::raw("Start filtering (searches all columns)"),
         ]),
         Line::from(vec![
-            Span::styled("  Esc         ", Style::default().fg(Color::Yellow)),
+            Span::styled("  Esc             ", Style::default().fg(Color::Yellow)),
             Span::raw("Clear filter"),
         ]),
         Line::from(""),
+        // Selectors section
         Line::from(vec![Span::styled(
-            "Commands",
+            "Selectors",
             Style::default().add_modifier(Modifier::BOLD),
         )]),
         Line::from(vec![
-            Span::styled("  :           ", Style::default().fg(Color::Yellow)),
-            Span::raw("Enter command mode"),
+            Span::styled("  p               ", Style::default().fg(Color::Yellow)),
+            Span::raw("Switch project (type to search)"),
         ]),
         Line::from(vec![
-            Span::styled("  p           ", Style::default().fg(Color::Yellow)),
-            Span::raw("Switch project"),
+            Span::styled("  z               ", Style::default().fg(Color::Yellow)),
+            Span::raw("Switch zone (type to search)"),
         ]),
         Line::from(vec![
-            Span::styled("  z           ", Style::default().fg(Color::Yellow)),
-            Span::raw("Switch zone"),
+            Span::styled("  :               ", Style::default().fg(Color::Yellow)),
+            Span::raw("Command mode (type resource name)"),
         ]),
         Line::from(""),
+        // Actions section
         Line::from(vec![Span::styled(
-            "Actions",
+            "Actions (VM Instances)",
             Style::default().add_modifier(Modifier::BOLD),
         )]),
         Line::from(vec![
-            Span::styled("  s           ", Style::default().fg(Color::Yellow)),
+            Span::styled("  s               ", Style::default().fg(Color::Yellow)),
             Span::raw("Start instance"),
         ]),
         Line::from(vec![
-            Span::styled("  S           ", Style::default().fg(Color::Yellow)),
+            Span::styled("  S               ", Style::default().fg(Color::Yellow)),
             Span::raw("Stop instance"),
         ]),
         Line::from(vec![
-            Span::styled("  r           ", Style::default().fg(Color::Yellow)),
+            Span::styled("  r               ", Style::default().fg(Color::Yellow)),
             Span::raw("Reset instance"),
         ]),
         Line::from(vec![
-            Span::styled("  Ctrl+d      ", Style::default().fg(Color::Red)),
+            Span::styled("  Delete          ", Style::default().fg(Color::Red)),
             Span::raw("Delete resource (destructive)"),
         ]),
         Line::from(""),
+        // General section
+        Line::from(vec![Span::styled(
+            "General",
+            Style::default().add_modifier(Modifier::BOLD),
+        )]),
         Line::from(vec![
-            Span::styled("  ?/Esc       ", Style::default().fg(Color::Yellow)),
-            Span::raw("Close help"),
+            Span::styled("  ?               ", Style::default().fg(Color::Yellow)),
+            Span::raw("Toggle help"),
         ]),
         Line::from(vec![
-            Span::styled("  q           ", Style::default().fg(Color::Yellow)),
+            Span::styled("  q               ", Style::default().fg(Color::Yellow)),
             Span::raw("Quit application"),
         ]),
     ];

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -164,9 +164,26 @@ fn render_dynamic_table(f: &mut Frame, app: &App, area: Rect) {
     let inner_area = block.inner(area);
     f.render_widget(block, area);
 
-    // Build header from column definitions with left padding
-    let header_cells = resource.columns.iter().map(|col| {
-        Cell::from(format!(" {}", col.header)).style(
+    // Build header from column definitions with left padding and sort indicators
+    let header_cells = resource.columns.iter().enumerate().map(|(idx, col)| {
+        // Add sort indicator if this column is sorted
+        let sort_indicator = if app.sort_column == Some(idx) {
+            if app.sort_ascending {
+                " ▲"
+            } else {
+                " ▼"
+            }
+        } else {
+            ""
+        };
+
+        let header_text = if app.sort_column == Some(idx) {
+            format!(" {}{}", col.header, sort_indicator)
+        } else {
+            format!(" {}", col.header)
+        };
+
+        Cell::from(header_text).style(
             Style::default()
                 .fg(Color::Yellow)
                 .add_modifier(Modifier::BOLD),

--- a/src/ui/projects.rs
+++ b/src/ui/projects.rs
@@ -1,13 +1,13 @@
 //! Projects Selector
 //!
-//! Project selection overlay.
+//! Project selection overlay with search functionality.
 
 use crate::app::App;
 use ratatui::{
     layout::{Alignment, Constraint, Direction, Layout, Rect},
     style::{Color, Modifier, Style},
-    text::Span,
-    widgets::{Block, Borders, Clear, List, ListItem, ListState},
+    text::{Line, Span},
+    widgets::{Block, Borders, Clear, List, ListItem, ListState, Paragraph},
     Frame,
 };
 
@@ -15,11 +15,18 @@ pub fn render(f: &mut Frame, app: &App, area: Rect) {
     let popup_area = centered_rect(60, 70, area);
     f.render_widget(Clear, popup_area);
 
+    // Title with count
+    let title = format!(
+        " Select Project [{}/{}] ",
+        app.projects_filtered.len(),
+        app.available_projects.len()
+    );
+
     let block = Block::default()
         .borders(Borders::ALL)
         .border_style(Style::default().fg(Color::Cyan))
         .title(Span::styled(
-            " Select Project ",
+            title,
             Style::default()
                 .fg(Color::Cyan)
                 .add_modifier(Modifier::BOLD),
@@ -29,8 +36,55 @@ pub fn render(f: &mut Frame, app: &App, area: Rect) {
     let inner = block.inner(popup_area);
     f.render_widget(block, popup_area);
 
+    // Split inner into: search box, help text, separator, list
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(1), // Search input
+            Constraint::Length(1), // Help text
+            Constraint::Length(1), // Separator
+            Constraint::Min(1),    // Project list
+        ])
+        .split(inner);
+
+    // Search input with cursor
+    let search_line = Line::from(vec![
+        Span::styled(" / ", Style::default().fg(Color::Yellow)),
+        Span::styled(
+            &app.projects_search_text,
+            Style::default().fg(Color::White),
+        ),
+        Span::styled("_", Style::default().fg(Color::Yellow)),
+    ]);
+    f.render_widget(
+        Paragraph::new(search_line).style(Style::default()),
+        chunks[0],
+    );
+
+    // Help text
+    let help = Line::from(vec![
+        Span::styled(" Type", Style::default().fg(Color::DarkGray)),
+        Span::styled(" to search", Style::default().fg(Color::DarkGray)),
+        Span::styled(" | ", Style::default().fg(Color::DarkGray)),
+        Span::styled("↑↓", Style::default().fg(Color::Yellow)),
+        Span::styled(":nav ", Style::default().fg(Color::DarkGray)),
+        Span::styled("Enter", Style::default().fg(Color::Yellow)),
+        Span::styled(":select ", Style::default().fg(Color::DarkGray)),
+        Span::styled("Esc", Style::default().fg(Color::Yellow)),
+        Span::styled(":cancel", Style::default().fg(Color::DarkGray)),
+    ]);
+    f.render_widget(Paragraph::new(help), chunks[1]);
+
+    // Separator line
+    let sep = "─".repeat(chunks[2].width as usize);
+    f.render_widget(
+        Paragraph::new(sep).style(Style::default().fg(Color::DarkGray)),
+        chunks[2],
+    );
+
+    // Filtered project list
     let items: Vec<ListItem> = app
-        .available_projects
+        .projects_filtered
         .iter()
         .map(|project| {
             let style = if project == &app.project {
@@ -40,7 +94,9 @@ pub fn render(f: &mut Frame, app: &App, area: Rect) {
             } else {
                 Style::default().fg(Color::White)
             };
-            ListItem::new(Span::styled(format!("  {}", project), style))
+            // Mark current project with a checkmark
+            let prefix = if project == &app.project { "✓ " } else { "  " };
+            ListItem::new(Span::styled(format!("{}{}", prefix, project), style))
         })
         .collect();
 
@@ -53,7 +109,7 @@ pub fn render(f: &mut Frame, app: &App, area: Rect) {
     let mut state = ListState::default();
     state.select(Some(app.projects_selected));
 
-    f.render_stateful_widget(list, inner, &mut state);
+    f.render_stateful_widget(list, chunks[3], &mut state);
 }
 
 fn centered_rect(percent_x: u16, percent_y: u16, r: Rect) -> Rect {


### PR DESCRIPTION
- Add searchable project/zone selectors (type to filter)
- Add column sorting with F1-F6 keys (toggle direction)
- Extend filtering to search ALL columns (not just name/id)
- Add accessible navigation: Home/End, 1-9 quick jump, PageUp/Down
- Resolve Ctrl+d conflict: use Delete key for destructive actions
- Increase gg timeout from 500ms to 1000ms for better UX
- Update help overlay with all new shortcuts
- Update header with sort indicator and accessible hints
- Add checkmarks for current selection in project/zone selectors
- Show match counts in selector titles (e.g., [42/215])

New shortcuts:
- Home/End: go to top/bottom (alternative to gg/G)
- 1-9: quick jump to first 9 items
- F1-F6: sort by column 1-6
- F12: clear sort
- Delete: delete resource (replaces Ctrl+d)
- Left arrow: go back (alternative to Backspace/b)
- PageUp/PageDown: in selectors and describe mode