### PR TITLE
refactor: remove dead code and unused dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1016,25 +1016,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "is-docker"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "928bae27f42bc99b60d9ac7334e3a21d10ad8f1835a4e12ec3ec0464765ed1b3"
-dependencies = [
- "once_cell",
-]
-
-[[package]]
-name = "is-wsl"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "173609498df190136aa7dea1a91db051746d339e18476eed5ca40521f02d7aa5"
-dependencies = [
- "is-docker",
- "once_cell",
-]
-
-[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1308,17 +1289,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
-name = "open"
-version = "5.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43bb73a7fa3799b198970490a51174027ba0d4ec504b03cd08caf513d40024bc"
-dependencies = [
- "is-wsl",
- "libc",
- "pathdiff",
-]
-
-[[package]]
 name = "openssl-probe"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1361,12 +1331,6 @@ dependencies = [
  "smallvec",
  "windows-link",
 ]
-
-[[package]]
-name = "pathdiff"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
 
 [[package]]
 name = "percent-encoding"
@@ -2279,18 +2243,15 @@ name = "tgcp"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "chrono",
  "clap",
  "crossterm",
  "dirs",
  "gcp_auth",
- "open",
  "ratatui",
  "reqwest",
  "serde",
  "serde_json",
  "serde_yaml",
- "thiserror 1.0.69",
  "tokio",
  "tracing",
  "tracing-appender",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,10 +41,7 @@ tracing-appender = "0.2"
 
 # Utils
 anyhow = "1.0"
-thiserror = "1.0"
 dirs = "6.0"
-chrono = { version = "0.4", default-features = false, features = ["std", "clock"] }
-open = "5.3"
 
 [dev-dependencies]
 dirs = "6.0"

--- a/src/app.rs
+++ b/src/app.rs
@@ -8,7 +8,7 @@ use crate::resource::{
     extract_json_value, fetch_resources_paginated, get_all_resource_keys, get_resource,
     ResourceDef, ResourceFilter,
 };
-use crate::theme::{Theme, ThemeManager};
+use crate::theme::ThemeManager;
 use anyhow::Result;
 use crossterm::event::KeyCode;
 use serde_json::Value;
@@ -33,8 +33,6 @@ pub struct PendingAction {
     pub sdk_method: String,
     pub resource_id: String,
     pub message: String,
-    #[allow(dead_code)]
-    pub default_no: bool,
     pub destructive: bool,
     pub selected_yes: bool,
 }
@@ -194,12 +192,6 @@ impl App {
             pagination: PaginationState::default(),
             theme_manager,
         }
-    }
-
-    /// Get current theme (for future UI theming)
-    #[allow(dead_code)]
-    pub fn theme(&self) -> &Theme {
-        self.theme_manager.current()
     }
 
     /// Check if auto-refresh is needed (disabled)
@@ -386,11 +378,6 @@ impl App {
         if self.sort_column.is_some() {
             self.apply_sort();
         }
-    }
-
-    #[allow(dead_code)]
-    pub fn toggle_filter(&mut self) {
-        self.filter_active = !self.filter_active;
     }
 
     pub fn clear_filter(&mut self) {
@@ -647,14 +634,12 @@ impl App {
         let message = config
             .message
             .unwrap_or_else(|| action.display_name.clone());
-        let default_no = !config.default_yes;
 
         Some(PendingAction {
             service: self.current_resource()?.service.clone(),
             sdk_method: action.sdk_method.clone(),
             resource_id: resource_id.to_string(),
             message: format!("{} '{}'?", message, resource_name),
-            default_no,
             destructive: config.destructive,
             selected_yes: config.default_yes,
         })

--- a/src/config.rs
+++ b/src/config.rs
@@ -127,14 +127,6 @@ impl Config {
         self.theme.clone().unwrap_or_else(|| "default".to_string())
     }
 
-    /// Set project-specific theme (for future :theme-project command)
-    #[allow(dead_code)]
-    pub fn set_project_theme(&mut self, project_id: &str, theme: &str) -> Result<()> {
-        self.project_themes
-            .insert(project_id.to_string(), theme.to_string());
-        self.save()
-    }
-
     /// Add alias
     pub fn add_alias(&mut self, alias: &str, resource_key: &str) -> Result<()> {
         self.aliases

--- a/src/event.rs
+++ b/src/event.rs
@@ -314,9 +314,6 @@ async fn handle_shell_action(
                 Ok(ShellResult::Error(msg)) => {
                     app.error_message = Some(msg);
                 },
-                Ok(ShellResult::Interrupted) => {
-                    tracing::info!("SSH session interrupted");
-                },
                 Err(e) => {
                     app.error_message = Some(format!("SSH error: {}", e));
                 },
@@ -340,9 +337,6 @@ async fn handle_shell_action(
                 },
                 Ok(ShellResult::Error(msg)) => {
                     app.error_message = Some(msg);
-                },
-                Ok(ShellResult::Interrupted) => {
-                    tracing::info!("SSH (IAP) session interrupted");
                 },
                 Err(e) => {
                     app.error_message = Some(format!("SSH (IAP) error: {}", e));

--- a/src/gcp/http.rs
+++ b/src/gcp/http.rs
@@ -4,16 +4,6 @@ use anyhow::{Context, Result};
 use reqwest::Client;
 use serde_json::Value;
 
-/// Base URLs for GCP services
-#[allow(dead_code)]
-pub mod base_urls {
-    pub const COMPUTE: &str = "https://compute.googleapis.com/compute/v1";
-    pub const STORAGE: &str = "https://storage.googleapis.com/storage/v1";
-    pub const CONTAINER: &str = "https://container.googleapis.com/v1";
-    pub const CLOUDRESOURCEMANAGER: &str = "https://cloudresourcemanager.googleapis.com/v1";
-    pub const IAM: &str = "https://iam.googleapis.com/v1";
-}
-
 /// HTTP client wrapper for GCP API calls
 #[derive(Clone)]
 pub struct GcpHttpClient {

--- a/src/gcp/projects.rs
+++ b/src/gcp/projects.rs
@@ -8,12 +8,8 @@ use serde_json::Value;
 
 /// Project information
 #[derive(Debug, Clone)]
-#[allow(dead_code)]
 pub struct Project {
     pub project_id: String,
-    pub name: String,
-    pub project_number: String,
-    pub lifecycle_state: String,
 }
 
 impl From<&Value> for Project {
@@ -23,21 +19,6 @@ impl From<&Value> for Project {
                 .get("projectId")
                 .and_then(|v| v.as_str())
                 .unwrap_or("-")
-                .to_string(),
-            name: value
-                .get("name")
-                .and_then(|v| v.as_str())
-                .unwrap_or("-")
-                .to_string(),
-            project_number: value
-                .get("projectNumber")
-                .and_then(|v| v.as_str())
-                .unwrap_or("-")
-                .to_string(),
-            lifecycle_state: value
-                .get("lifecycleState")
-                .and_then(|v| v.as_str())
-                .unwrap_or("UNKNOWN")
                 .to_string(),
         }
     }

--- a/src/resource/registry.rs
+++ b/src/resource/registry.rs
@@ -62,17 +62,10 @@ pub struct ConfirmConfig {
 /// Action definition from JSON
 #[derive(Debug, Clone, Deserialize)]
 pub struct ActionDef {
-    /// Key identifier for the action
-    #[allow(dead_code)]
-    pub key: String,
     pub display_name: String,
     #[serde(default)]
     pub shortcut: Option<String>,
     pub sdk_method: String,
-    /// Parameter name for the resource ID
-    #[serde(default)]
-    #[allow(dead_code)]
-    pub id_param: Option<String>,
     /// Legacy field - use `confirm` instead
     #[serde(default)]
     pub needs_confirm: bool,

--- a/src/resource/sdk_dispatch.rs
+++ b/src/resource/sdk_dispatch.rs
@@ -48,38 +48,6 @@ pub async fn execute_action(
     }
 }
 
-/// Describe a single resource
-#[allow(dead_code)]
-pub async fn describe_resource(
-    resource_key: &str,
-    client: &GcpClient,
-    resource_id: &str,
-) -> Result<Value> {
-    let Some(resource_def) = super::get_resource(resource_key) else {
-        return Err(anyhow::anyhow!("Unknown resource: {}", resource_key));
-    };
-
-    // Build describe method name from list method
-    let describe_method = resource_def
-        .detail_sdk_method
-        .as_deref()
-        .unwrap_or_else(|| {
-            // Derive from list method: list_instances -> get_instance
-            if resource_def.sdk_method.starts_with("list_") {
-                // Can't modify &str, so just use the original
-                &resource_def.sdk_method
-            } else {
-                &resource_def.sdk_method
-            }
-        });
-
-    let params = serde_json::json!({
-        "name": resource_id
-    });
-
-    invoke_sdk(&resource_def.service, describe_method, client, &params).await
-}
-
 // =============================================================================
 // Compute Engine
 // =============================================================================

--- a/src/shell/mod.rs
+++ b/src/shell/mod.rs
@@ -44,9 +44,6 @@ pub enum ShellResult {
     Success,
     /// Command failed with exit code
     Failed(i32),
-    /// Command was interrupted (for future use)
-    #[allow(dead_code)]
-    Interrupted,
     /// Error launching command
     Error(String),
 }
@@ -74,60 +71,6 @@ pub fn ssh_to_instance(opts: &SshOptions) -> ShellResult {
     tracing::info!("Executing: gcloud {}", args.join(" "));
 
     execute_command("gcloud", &args)
-}
-
-/// Execute serial console connection (for future use)
-#[allow(dead_code)]
-pub fn serial_console(instance: &str, zone: &str, project: &str, port: u8) -> ShellResult {
-    let args = vec![
-        "compute".to_string(),
-        "connect-to-serial-port".to_string(),
-        instance.to_string(),
-        "--zone".to_string(),
-        zone.to_string(),
-        "--project".to_string(),
-        project.to_string(),
-        "--port".to_string(),
-        port.to_string(),
-    ];
-
-    tracing::info!("Executing: gcloud {}", args.join(" "));
-
-    execute_command("gcloud", &args)
-}
-
-/// Execute kubectl exec into a pod (for future GKE exec support)
-#[allow(dead_code)]
-pub fn kubectl_exec(
-    pod: &str,
-    namespace: &str,
-    container: Option<&str>,
-    command: &[&str],
-) -> ShellResult {
-    let mut args = vec![
-        "exec".to_string(),
-        "-it".to_string(),
-        pod.to_string(),
-        "-n".to_string(),
-        namespace.to_string(),
-    ];
-
-    if let Some(c) = container {
-        args.push("-c".to_string());
-        args.push(c.to_string());
-    }
-
-    args.push("--".to_string());
-
-    if command.is_empty() {
-        args.push("/bin/sh".to_string());
-    } else {
-        args.extend(command.iter().map(|s| s.to_string()));
-    }
-
-    tracing::info!("Executing: kubectl {}", args.join(" "));
-
-    execute_command("kubectl", &args)
 }
 
 /// Open URL in browser (for console links)


### PR DESCRIPTION
- Remove unused dependencies: chrono, open, thiserror
- Remove unused functions: get_default_region, list_regions, describe_resource, serial_console, kubectl_exec, toggle_filter, rgb_to_color, save_to_file, set_project_theme, get_project_theme, apply_project_theme
- Remove unused struct fields: PendingAction::default_no, Project::name, Project::project_number, Project::lifecycle_state, ActionDef::key, ActionDef::id_param, ThemeManager::project_themes
- Remove unused enum variant: ShellResult::Interrupted
- Remove unused module: base_urls in gcp/http.rs
- Remove unused imports: Theme in app.rs, Color and HashMap in theme/mod.rs

Total: 323 lines of dead code removed across 12 files.