### PR TITLE
feat: add notification system for GCE operations

### DIFF
--- a/src/gcp/client.rs
+++ b/src/gcp/client.rs
@@ -199,18 +199,6 @@ impl GcpClient {
     // Operations API helpers
     // =========================================================================
 
-    /// Build zonal operations URL
-    #[allow(dead_code)]
-    pub fn compute_zonal_operation_url(&self, operation: &str) -> String {
-        self.compute_url(&format!("zones/{}/operations/{}", self.zone, operation))
-    }
-
-    /// Build global operations URL
-    #[allow(dead_code)]
-    pub fn compute_global_operation_url(&self, operation: &str) -> String {
-        self.compute_url(&format!("global/operations/{}", operation))
-    }
-
     /// Poll a GCP operation until completion
     /// Returns the operation status: "RUNNING", "DONE", or error
     pub async fn poll_operation(&self, operation_url: &str) -> Result<OperationStatus> {
@@ -252,26 +240,10 @@ pub enum OperationStatus {
     Unknown(String),
 }
 
-impl OperationStatus {
-    #[allow(dead_code)]
-    pub fn is_terminal(&self) -> bool {
-        matches!(self, Self::Done | Self::Failed(_))
-    }
-}
-
 /// Extract operation self-link URL from a GCP API response
 pub fn extract_operation_url(response: &Value) -> Option<String> {
     response
         .get("selfLink")
-        .and_then(|v| v.as_str())
-        .map(String::from)
-}
-
-/// Extract operation name from a GCP API response
-#[allow(dead_code)]
-pub fn extract_operation_name(response: &Value) -> Option<String> {
-    response
-        .get("name")
         .and_then(|v| v.as_str())
         .map(String::from)
 }

--- a/src/notification.rs
+++ b/src/notification.rs
@@ -27,15 +27,6 @@ impl DetailLevel {
             _ => Self::Detailed,
         }
     }
-
-    #[allow(dead_code)]
-    pub fn as_str(&self) -> &'static str {
-        match self {
-            Self::Minimal => "minimal",
-            Self::Detailed => "detailed",
-            Self::Verbose => "verbose",
-        }
-    }
 }
 
 /// Sound configuration for notifications
@@ -56,15 +47,6 @@ impl SoundConfig {
             "errors_only" | "errors" => Self::ErrorsOnly,
             "all" => Self::All,
             _ => Self::Off,
-        }
-    }
-
-    #[allow(dead_code)]
-    pub fn as_str(&self) -> &'static str {
-        match self {
-            Self::Off => "off",
-            Self::ErrorsOnly => "errors_only",
-            Self::All => "all",
         }
     }
 }
@@ -157,8 +139,6 @@ pub struct Notification {
     pub resource_type: String,
     pub resource_id: String,
     pub status: NotificationStatus,
-    #[allow(dead_code)]
-    pub message: Option<String>,
     pub gcp_operation_url: Option<String>,
     pub created_at: Instant,
     pub completed_at: Option<Instant>,
@@ -172,7 +152,6 @@ impl Notification {
             resource_type,
             resource_id,
             status: NotificationStatus::Pending,
-            message: None,
             gcp_operation_url: None,
             created_at: Instant::now(),
             completed_at: None,
@@ -398,12 +377,6 @@ impl NotificationManager {
         }
     }
 
-    /// Get notification by ID
-    #[allow(dead_code)]
-    pub fn get(&self, id: Uuid) -> Option<&Notification> {
-        self.notifications.iter().find(|n| n.id == id)
-    }
-
     /// Get the most recent active notification (for toast display)
     pub fn current_toast(&self) -> Option<&Notification> {
         // Check if toast should still be visible
@@ -473,22 +446,6 @@ impl NotificationManager {
     fn play_beep(&self) {
         print!("\x07");
     }
-
-    /// Check if there are any notifications to show
-    #[allow(dead_code)]
-    pub fn has_notifications(&self) -> bool {
-        !self.notifications.is_empty()
-    }
-
-    /// Get count of unread/recent notifications (last 5 minutes)
-    #[allow(dead_code)]
-    pub fn recent_count(&self) -> usize {
-        let cutoff = Duration::from_secs(300); // 5 minutes
-        self.notifications
-            .iter()
-            .filter(|n| n.created_at.elapsed() < cutoff)
-            .count()
-    }
 }
 
 #[cfg(test)]
@@ -508,21 +465,21 @@ mod tests {
 
         assert_eq!(manager.notifications.len(), 1);
         assert!(matches!(
-            manager.get(id).unwrap().status,
+            manager.notifications.front().unwrap().status,
             NotificationStatus::Pending
         ));
 
         // Mark in progress
         manager.mark_in_progress(id, Some("https://example.com/op/123".to_string()));
         assert!(matches!(
-            manager.get(id).unwrap().status,
+            manager.notifications.front().unwrap().status,
             NotificationStatus::InProgress
         ));
 
         // Mark success
         manager.mark_success(id);
         assert!(matches!(
-            manager.get(id).unwrap().status,
+            manager.notifications.front().unwrap().status,
             NotificationStatus::Success
         ));
     }


### PR DESCRIPTION
## Summary

- Add comprehensive notification system for tracking GCE operations (start, stop, reset, delete)
- Display toast notifications in footer with configurable detail levels (minimal, detailed, verbose)
- Add notification history panel accessible via `n` key
- Implement GCP Operations API polling for real-time status updates
- Add configurable settings: toast duration, poll interval, sound alerts, auto-polling

## Changes

### New files
- `src/notification.rs` - Core notification module with `Notification`, `NotificationManager`, `OperationType`, `DetailLevel`, `SoundConfig`
- `src/ui/notifications.rs` - History panel overlay UI

### Modified files
- `src/app.rs` - Integrated `NotificationManager`, added `Mode::Notifications`
- `src/config.rs` - Added `NotificationConfig` with persistence
- `src/event.rs` - Added `n` key handling and notification integration for actions
- `src/gcp/client.rs` - Added `poll_operation` and `OperationStatus` enum
- `src/main.rs` - Added polling in event loop
- `src/ui/mod.rs` - Enhanced footer with toast display and notification indicator
- `src/ui/help.rs` - Added documentation for `n` key

## Test plan

- [x] Run `cargo clippy --all-targets --all-features -- -D warnings`
- [x] Run `cargo test`
- [x] Run `cargo fmt --check`
- [ ] Manual test: Start/stop VM and verify toast notification appears
- [ ] Manual test: Press `n` to view notification history
- [ ] Manual test: Verify polling updates notification status

🤖 Generated with [Claude Code](https://claude.com/claude-code)