### PR TITLE
style: fix formatting in test files

### DIFF
--- a/tests/http_integration.rs
+++ b/tests/http_integration.rs
@@ -24,7 +24,9 @@ mod http_client_tests {
         });
 
         Mock::given(method("GET"))
-            .and(path("/compute/v1/projects/test-project/zones/us-central1-a/instances"))
+            .and(path(
+                "/compute/v1/projects/test-project/zones/us-central1-a/instances",
+            ))
             .and(bearer_token("test-token"))
             .respond_with(ResponseTemplate::new(200).set_body_json(&expected_response))
             .mount(&server)
@@ -57,14 +59,12 @@ mod http_client_tests {
 
         Mock::given(method("GET"))
             .and(path("/compute/v1/projects/test-project/instances"))
-            .respond_with(
-                ResponseTemplate::new(401).set_body_json(json!({
-                    "error": {
-                        "code": 401,
-                        "message": "Invalid credentials"
-                    }
-                })),
-            )
+            .respond_with(ResponseTemplate::new(401).set_body_json(json!({
+                "error": {
+                    "code": 401,
+                    "message": "Invalid credentials"
+                }
+            })))
             .mount(&server)
             .await;
 
@@ -90,14 +90,12 @@ mod http_client_tests {
 
         Mock::given(method("GET"))
             .and(path("/compute/v1/projects/restricted-project/instances"))
-            .respond_with(
-                ResponseTemplate::new(403).set_body_json(json!({
-                    "error": {
-                        "code": 403,
-                        "message": "Permission denied"
-                    }
-                })),
-            )
+            .respond_with(ResponseTemplate::new(403).set_body_json(json!({
+                "error": {
+                    "code": 403,
+                    "message": "Permission denied"
+                }
+            })))
             .mount(&server)
             .await;
 
@@ -123,15 +121,15 @@ mod http_client_tests {
         let server = MockServer::start().await;
 
         Mock::given(method("GET"))
-            .and(path("/compute/v1/projects/test-project/zones/invalid-zone/instances"))
-            .respond_with(
-                ResponseTemplate::new(404).set_body_json(json!({
-                    "error": {
-                        "code": 404,
-                        "message": "Zone not found"
-                    }
-                })),
-            )
+            .and(path(
+                "/compute/v1/projects/test-project/zones/invalid-zone/instances",
+            ))
+            .respond_with(ResponseTemplate::new(404).set_body_json(json!({
+                "error": {
+                    "code": 404,
+                    "message": "Zone not found"
+                }
+            })))
             .mount(&server)
             .await;
 
@@ -164,7 +162,9 @@ mod http_client_tests {
         });
 
         Mock::given(method("POST"))
-            .and(path("/compute/v1/projects/test-project/zones/us-central1-a/instances/my-vm/start"))
+            .and(path(
+                "/compute/v1/projects/test-project/zones/us-central1-a/instances/my-vm/start",
+            ))
             .and(bearer_token("test-token"))
             .respond_with(ResponseTemplate::new(200).set_body_json(&operation_response))
             .mount(&server)
@@ -202,7 +202,9 @@ mod http_client_tests {
         });
 
         Mock::given(method("DELETE"))
-            .and(path("/compute/v1/projects/test-project/zones/us-central1-a/instances/my-vm"))
+            .and(path(
+                "/compute/v1/projects/test-project/zones/us-central1-a/instances/my-vm",
+            ))
             .and(bearer_token("test-token"))
             .respond_with(ResponseTemplate::new(200).set_body_json(&operation_response))
             .mount(&server)
@@ -260,14 +262,12 @@ mod http_client_tests {
 
         Mock::given(method("GET"))
             .and(path("/rate-limited"))
-            .respond_with(
-                ResponseTemplate::new(429).set_body_json(json!({
-                    "error": {
-                        "code": 429,
-                        "message": "Rate limit exceeded"
-                    }
-                })),
-            )
+            .respond_with(ResponseTemplate::new(429).set_body_json(json!({
+                "error": {
+                    "code": 429,
+                    "message": "Rate limit exceeded"
+                }
+            })))
             .mount(&server)
             .await;
 

--- a/tests/proptest_filters.rs
+++ b/tests/proptest_filters.rs
@@ -9,10 +9,15 @@ use serde_json::{json, Value};
 /// Generate arbitrary VM instance data for testing
 fn arb_instance() -> impl Strategy<Value = Value> {
     (
-        "[a-z][a-z0-9-]{0,62}",              // name
+        "[a-z][a-z0-9-]{0,62}", // name
         prop_oneof!["RUNNING", "STOPPED", "TERMINATED", "PENDING", "STAGING"],
-        "[a-z]+-[a-z]+[0-9]-[a-z]",          // zone
-        prop_oneof!["n1-standard-1", "n2-standard-2", "e2-medium", "c2-standard-4"],
+        "[a-z]+-[a-z]+[0-9]-[a-z]", // zone
+        prop_oneof![
+            "n1-standard-1",
+            "n2-standard-2",
+            "e2-medium",
+            "c2-standard-4"
+        ],
     )
         .prop_map(|(name, status, zone, machine_type)| {
             json!({
@@ -182,11 +187,17 @@ mod input_validation_tests {
             return false;
         }
         // Must start with lowercase letter
-        if !s.chars().next().map(|c| c.is_ascii_lowercase()).unwrap_or(false) {
+        if !s
+            .chars()
+            .next()
+            .map(|c| c.is_ascii_lowercase())
+            .unwrap_or(false)
+        {
             return false;
         }
         // Only lowercase letters, digits, and hyphens
-        s.chars().all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-')
+        s.chars()
+            .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-')
     }
 
     /// Validate zone format (region-zone, e.g., us-central1-a)
@@ -196,7 +207,9 @@ mod input_validation_tests {
             return false;
         }
         // All parts should be alphanumeric
-        parts.iter().all(|p| p.chars().all(|c| c.is_ascii_alphanumeric()))
+        parts
+            .iter()
+            .all(|p| p.chars().all(|c| c.is_ascii_alphanumeric()))
     }
 
     proptest! {


### PR DESCRIPTION
## Summary
- Run cargo fmt to fix formatting inconsistencies in test files
- Fixes CI format check failure

## Test plan
- [x] cargo fmt --check passes locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)