### PR TITLE
feat: add Cloud Monitoring metrics to VM instances list

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2424,6 +2424,7 @@ name = "tgcp"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "chrono",
  "clap",
  "crossterm",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ tracing-appender = "0.2"
 anyhow = "1.0"
 dirs = "6.0"
 uuid = { version = "1.11", features = ["v4"] }
+chrono = "0.4"
 
 [dev-dependencies]
 dirs = "6.0"

--- a/src/gcp/client.rs
+++ b/src/gcp/client.rs
@@ -166,6 +166,18 @@ impl GcpClient {
     }
 
     // =========================================================================
+    // Cloud Monitoring API helpers
+    // =========================================================================
+
+    /// Build Cloud Monitoring API URL
+    pub fn monitoring_url(&self, path: &str) -> String {
+        format!(
+            "https://monitoring.googleapis.com/v3/projects/{}/{}",
+            self.project_id, path
+        )
+    }
+
+    // =========================================================================
     // Resource Manager API helpers
     // =========================================================================
 

--- a/src/resource/mod.rs
+++ b/src/resource/mod.rs
@@ -35,8 +35,8 @@ pub mod sdk_dispatch;
 
 #[allow(unused_imports)]
 pub use fetcher::{
-    extract_json_value, fetch_multiple_resources, fetch_resources, fetch_resources_concurrent,
-    fetch_resources_paginated, ResourceFilter,
+    enrich_with_metrics, extract_json_value, fetch_multiple_resources, fetch_resources,
+    fetch_resources_concurrent, fetch_resources_paginated, ResourceFilter,
 };
 pub use registry::*;
 pub use sdk_dispatch::execute_action;

--- a/src/resources/compute.json
+++ b/src/resources/compute.json
@@ -12,14 +12,15 @@
       "is_regional": false,
       "columns": [
         { "header": "NAME", "json_path": "name", "width": 25 },
-        { "header": "STATUS", "json_path": "status", "width": 12, "color_map": "status" },
+        { "header": "STATUS", "json_path": "status", "width": 10, "color_map": "status" },
         { "header": "ZONE", "json_path": "zone_short", "width": 15 },
-        { "header": "MACHINE TYPE", "json_path": "machineType_short", "width": 15 },
-        { "header": "vCPUs", "json_path": "vcpus", "width": 6 },
-        { "header": "TYPE", "json_path": "scheduling_display", "width": 8 },
-        { "header": "DISKS", "json_path": "disks_count", "width": 6 },
-        { "header": "INTERNAL IP", "json_path": "networkInterfaces.0.networkIP", "width": 15 },
-        { "header": "CREATED", "json_path": "creationTimestamp_short", "width": 12 }
+        { "header": "TYPE", "json_path": "machineType_short", "width": 14 },
+        { "header": "CPU", "json_path": "metrics_cpu", "width": 7 },
+        { "header": "NET IN", "json_path": "metrics_net_in", "width": 10 },
+        { "header": "NET OUT", "json_path": "metrics_net_out", "width": 10 },
+        { "header": "DISK R", "json_path": "metrics_disk_read", "width": 10 },
+        { "header": "DISK W", "json_path": "metrics_disk_write", "width": 10 },
+        { "header": "IP", "json_path": "networkInterfaces.0.networkIP", "width": 15 }
       ],
       "sub_resources": [
         {


### PR DESCRIPTION
Add real-time resource utilization metrics (CPU, Network, Disk IO) to the compute-instances table using the Cloud Monitoring API.

New columns displayed for VM instances:
- CPU: CPU utilization percentage
- NET IN/OUT: Network traffic (bytes/sec)
- DISK R/W: Disk read/write throughput (bytes/sec)

Implementation details:
- Add monitoring_url() helper to GcpClient
- Add "monitoring" service to SDK dispatch with get_instance_metrics method
- Fetch metrics in parallel for all instances using futures::join_all
- Add enrich_with_metrics() function to merge metrics into VM data
- Metrics are fetched as 5-minute averages from Cloud Monitoring API

If metrics are unavailable (instance stopped, no permissions, etc.), "-" is displayed gracefully without failing the VM list.

Requires: roles/monitoring.viewer or monitoring.timeSeries.list permission