### PR TITLE
refactor: decompose App struct into logical sub-structs

### DIFF
--- a/src/ui/command_box.rs
+++ b/src/ui/command_box.rs
@@ -42,29 +42,29 @@ pub fn render(f: &mut Frame, app: &App) {
         ));
 
     // Show input with ghost text preview
-    let input_content = if let Some(preview) = &app.command_preview {
-        if app.command_text.is_empty() {
+    let input_content = if let Some(preview) = &app.command.preview {
+        if app.command.text.is_empty() {
             Line::from(vec![
                 Span::styled(":", Style::default().fg(Color::Cyan)),
                 Span::styled(preview, Style::default().fg(Color::DarkGray)),
             ])
-        } else if preview.starts_with(&app.command_text) {
-            let remaining = &preview[app.command_text.len()..];
+        } else if preview.starts_with(&app.command.text) {
+            let remaining = &preview[app.command.text.len()..];
             Line::from(vec![
                 Span::styled(":", Style::default().fg(Color::Cyan)),
-                Span::styled(&app.command_text, Style::default().fg(Color::White)),
+                Span::styled(&app.command.text, Style::default().fg(Color::White)),
                 Span::styled(remaining, Style::default().fg(Color::DarkGray)),
             ])
         } else {
             Line::from(vec![
                 Span::styled(":", Style::default().fg(Color::Cyan)),
-                Span::styled(&app.command_text, Style::default().fg(Color::White)),
+                Span::styled(&app.command.text, Style::default().fg(Color::White)),
             ])
         }
     } else {
         Line::from(vec![
             Span::styled(":", Style::default().fg(Color::Cyan)),
-            Span::styled(&app.command_text, Style::default().fg(Color::White)),
+            Span::styled(&app.command.text, Style::default().fg(Color::White)),
         ])
     };
 
@@ -81,12 +81,13 @@ pub fn render(f: &mut Frame, app: &App) {
         ));
 
     let suggestions: Vec<ListItem> = app
-        .command_suggestions
+        .command
+        .suggestions
         .iter()
         .enumerate()
         .take(8)
         .map(|(i, cmd)| {
-            let style = if i == app.command_suggestion_selected {
+            let style = if i == app.command.suggestion_selected {
                 Style::default()
                     .fg(Color::Black)
                     .bg(Color::Cyan)

--- a/src/ui/header.rs
+++ b/src/ui/header.rs
@@ -154,12 +154,12 @@ pub fn render(f: &mut Frame, app: &App, area: Rect) {
     ];
 
     // Add sort indicator if active
-    if let Some(col) = app.sort_column {
+    if let Some(col) = app.filter_sort.sort_column {
         help_spans.push(Span::styled(
             format!(
                 "[sorted:col{}{}]",
                 col + 1,
-                if app.sort_ascending { "↑" } else { "↓" }
+                if app.filter_sort.sort_ascending { "↑" } else { "↓" }
             ),
             Style::default().fg(Color::Cyan),
         ));

--- a/src/ui/projects.rs
+++ b/src/ui/projects.rs
@@ -18,7 +18,7 @@ pub fn render(f: &mut Frame, app: &App, area: Rect) {
     // Title with count
     let title = format!(
         " Select Project [{}/{}] ",
-        app.projects_filtered.len(),
+        app.projects_selector.filtered.len(),
         app.available_projects.len()
     );
 
@@ -50,7 +50,7 @@ pub fn render(f: &mut Frame, app: &App, area: Rect) {
     // Search input with cursor
     let search_line = Line::from(vec![
         Span::styled(" / ", Style::default().fg(Color::Yellow)),
-        Span::styled(&app.projects_search_text, Style::default().fg(Color::White)),
+        Span::styled(&app.projects_selector.search_text, Style::default().fg(Color::White)),
         Span::styled("_", Style::default().fg(Color::Yellow)),
     ]);
     f.render_widget(
@@ -81,7 +81,8 @@ pub fn render(f: &mut Frame, app: &App, area: Rect) {
 
     // Filtered project list
     let items: Vec<ListItem> = app
-        .projects_filtered
+        .projects_selector
+        .filtered
         .iter()
         .map(|project| {
             let style = if project == &app.project {
@@ -108,7 +109,7 @@ pub fn render(f: &mut Frame, app: &App, area: Rect) {
     );
 
     let mut state = ListState::default();
-    state.select(Some(app.projects_selected));
+    state.select(Some(app.projects_selector.selected));
 
     f.render_stateful_widget(list, chunks[3], &mut state);
 }

--- a/src/ui/zones.rs
+++ b/src/ui/zones.rs
@@ -18,7 +18,7 @@ pub fn render(f: &mut Frame, app: &App, area: Rect) {
     // Title with count
     let title = format!(
         " Select Zone [{}/{}] ",
-        app.zones_filtered.len(),
+        app.zones_selector.filtered.len(),
         app.available_zones.len()
     );
 
@@ -50,7 +50,7 @@ pub fn render(f: &mut Frame, app: &App, area: Rect) {
     // Search input with cursor
     let search_line = Line::from(vec![
         Span::styled(" / ", Style::default().fg(Color::Yellow)),
-        Span::styled(&app.zones_search_text, Style::default().fg(Color::White)),
+        Span::styled(&app.zones_selector.search_text, Style::default().fg(Color::White)),
         Span::styled("_", Style::default().fg(Color::Yellow)),
     ]);
     f.render_widget(
@@ -81,7 +81,8 @@ pub fn render(f: &mut Frame, app: &App, area: Rect) {
 
     // Filtered zone list
     let items: Vec<ListItem> = app
-        .zones_filtered
+        .zones_selector
+        .filtered
         .iter()
         .map(|zone| {
             let style = if zone == &app.zone {
@@ -114,7 +115,7 @@ pub fn render(f: &mut Frame, app: &App, area: Rect) {
     );
 
     let mut state = ListState::default();
-    state.select(Some(app.zones_selected));
+    state.select(Some(app.zones_selector.selected));
 
     f.render_stateful_widget(list, chunks[3], &mut state);
 }


### PR DESCRIPTION
## Summary
- Decompose monolithic App struct (~35 fields) into 6 focused sub-structs
- Each sub-struct manages related state: navigation, selection, filtering/sorting, command mode, selectors, and describe view
- Update all UI modules (mod.rs, zones.rs, projects.rs, header.rs, command_box.rs) to use new sub-struct paths
- Update event.rs handlers to use new sub-struct paths
- Clean up unused backward-compatible accessor methods

## Sub-structs introduced
| Struct | Purpose |
|--------|---------|
| `NavigationState` | List scrolling, hierarchical navigation, breadcrumbs |
| `SelectionState` | Multi-selection indices, visual mode |
| `FilterSortState` | Filter text/active, sort column/direction |
| `CommandState` | Command input, suggestions, preview |
| `SelectorState` | Reusable for project/zone dialogs |
| `DescribeState` | Detail view scrolling and data |

## Test plan
- [x] All 65 tests pass
- [x] `cargo clippy` has no warnings
- [x] Build succeeds with no warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)