### PR TITLE
feat: publish Docker image to GHCR on release

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+target/
+.git/
+.github/
+*.md
+LICENSE

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,7 @@ env:
 
 permissions:
   contents: write
+  packages: write
 
 jobs:
   # Create the release first
@@ -162,10 +163,50 @@ jobs:
             ${{ matrix.asset_name }}.zip
             ${{ matrix.asset_name }}.zip.sha256
 
+  # Build and push Docker image to GitHub Container Registry
+  docker:
+    name: Docker Image
+    needs: create-release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=semver,pattern={{version}},value=${{ needs.create-release.outputs.version }}
+            type=semver,pattern={{major}}.{{minor}},value=${{ needs.create-release.outputs.version }}
+            type=raw,value=latest
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            TGCP_VERSION=${{ needs.create-release.outputs.version }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
   # Publish release after all builds complete
   publish-release:
     name: Publish Release
-    needs: [create-release, build]
+    needs: [create-release, build, docker]
     runs-on: ubuntu-latest
     steps:
       - name: Publish release

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+FROM rust:1.86-slim AS builder
+
+WORKDIR /app
+
+# Install musl tools for static binary
+RUN apt-get update && apt-get install -y musl-tools && rm -rf /var/lib/apt/lists/*
+RUN rustup target add x86_64-unknown-linux-musl
+
+# Cache dependencies
+COPY Cargo.toml Cargo.lock ./
+RUN mkdir src && echo "fn main() {}" > src/main.rs
+RUN cargo build --release --target x86_64-unknown-linux-musl || true
+RUN rm -rf src
+
+# Build actual binary
+COPY . .
+ARG TGCP_VERSION=dev
+ENV TGCP_VERSION=${TGCP_VERSION}
+RUN cargo build --release --target x86_64-unknown-linux-musl
+RUN cp target/x86_64-unknown-linux-musl/release/tgcp /tgcp
+
+FROM scratch
+COPY --from=builder /tgcp /tgcp
+ENTRYPOINT ["/tgcp"]


### PR DESCRIPTION
## Summary
- Add `Dockerfile` (multi-stage build, static musl binary, `scratch` image)
- Add `.dockerignore` to optimize build context
- Update release workflow to build and push Docker image to `ghcr.io/mrmichou/tgcp` with semver tags
- Package will appear on the repo's GitHub Packages tab

## Test plan
- [ ] Trigger a release (tag or workflow_dispatch) and verify the Docker image is pushed to GHCR
- [ ] Verify the package appears on https://github.com/MrMichou?tab=packages&repo_name=tgcp
- [ ] Test `docker run ghcr.io/mrmichou/tgcp --help`

🤖 Generated with [Claude Code](https://claude.com/claude-code)