### PR TITLE
chore: bump version to 0.4.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tgcp"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 description = "Terminal UI for GCP - navigate, observe, and manage Google Cloud Platform resources"
 license = "MIT"


### PR DESCRIPTION
## Summary
- Bump version to 0.4.1 in preparation for release with Docker/GHCR support

## Test plan
- [ ] Merge, then tag `v0.4.1` to trigger release workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)