### PR TITLE
fix: add missing build deps in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM rust:1.86-slim AS builder
 WORKDIR /app
 
 # Install musl tools for static binary
-RUN apt-get update && apt-get install -y musl-tools && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y musl-tools pkg-config perl make && rm -rf /var/lib/apt/lists/*
 RUN rustup target add x86_64-unknown-linux-musl
 
 # Cache dependencies


### PR DESCRIPTION
## Summary
- Add `pkg-config`, `perl`, and `make` to Dockerfile build stage
- These are required by `ring` (used by `rustls`) during musl compilation

## Test plan
- [ ] Merge, then re-tag v0.4.1 to trigger release with fixed Docker build

🤖 Generated with [Claude Code](https://claude.com/claude-code)