### PR TITLE
fix: bump Rust to 1.88 in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.86-slim AS builder
+FROM rust:1.88-slim AS builder
 
 WORKDIR /app
 


### PR DESCRIPTION
## Summary
- Bump `rust:1.86-slim` → `rust:1.88-slim` in Dockerfile
- Required because `darling@0.23`, `time@0.3.47`, and `instability@0.3.11` need rustc 1.88+

## Test plan
- [ ] Merge, re-tag v0.4.1, verify Docker build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)