### PR TITLE
fix(security): bump quinn-proto to 0.11.15 (RUSTSEC-2026-0185)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1783,9 +1783,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",


### PR DESCRIPTION
## Summary

The Security workflow (`cargo audit`) was failing on `main` due to a real vulnerability in the transitive dependency `quinn-proto`.

- **Advisory**: [RUSTSEC-2026-0185](https://rustsec.org/advisories/RUSTSEC-2026-0185)
- **Crate**: `quinn-proto` 0.11.14 → **0.11.15**
- **Issue**: Remote memory exhaustion from unbounded out-of-order stream reassembly
- **Severity**: 7.5 (high)

## Changes

- Bumped `quinn-proto` to 0.11.15 via `cargo update -p quinn-proto` (lockfile-only change).

## Verification

- ✅ `cargo build --release`
- ✅ `cargo test` — 257 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)